### PR TITLE
Fix handling of spaces in executable names by using %r instead of re.escape

### DIFF
--- a/esky/bdist_esky/f_bbfreeze.py
+++ b/esky/bdist_esky/f_bbfreeze.py
@@ -8,7 +8,6 @@
 
 
 import os
-import re
 import sys
 import imp
 import time
@@ -76,8 +75,8 @@ def freeze(dist):
     #  For win32 we include a special chainloader that can suck the selected
     #  version into the running process rather than spawn a new proc.
     code_source = ["__name__ = '__main__'"]
-    esky_name = re.escape(dist.distribution.get_name())
-    code_source.append("__esky_name__ = '%s'" % (esky_name,))
+    esky_name = dist.distribution.get_name()
+    code_source.append("__esky_name__ = %r" % (esky_name,))
     code_source.append(inspect.getsource(esky.bootstrap))
     if dist.compile_bootstrap_exes:
         if sys.platform == "win32":

--- a/esky/bdist_esky/f_cxfreeze.py
+++ b/esky/bdist_esky/f_cxfreeze.py
@@ -8,7 +8,6 @@
 
 
 import os
-import re
 import sys
 import imp
 import time
@@ -90,8 +89,8 @@ def freeze(dist):
             raise RuntimeError(err)
     #  Create the bootstrap code, using custom code if specified.
     code_source = ["__name__ = '__main__'"]
-    esky_name = re.escape(dist.distribution.get_name())
-    code_source.append("__esky_name__ = '%s'" % (esky_name,))
+    esky_name = dist.distribution.get_name()
+    code_source.append("__esky_name__ = %r" % (esky_name,))
     code_source.append(inspect.getsource(esky.bootstrap))
     if dist.compile_bootstrap_exes:
         if sys.platform == "win32":

--- a/esky/bdist_esky/f_py2app.py
+++ b/esky/bdist_esky/f_py2app.py
@@ -10,7 +10,6 @@ from __future__ import with_statement
 
 
 import os
-import re
 import sys
 import imp
 import time
@@ -90,8 +89,8 @@ def freeze(dist):
         lib.write(src,arcnm)
     lib.close()
     #  Create the bootstraping code, using custom code if specified.
-    esky_name = re.escape(dist.distribution.get_name())
-    code_source = ["__esky_name__ = '%s'" % (esky_name,)]
+    esky_name = dist.distribution.get_name()
+    code_source = ["__esky_name__ = %r" % (esky_name,)]
     code_source.append(inspect.getsource(esky.bootstrap))
     if not dist.compile_bootstrap_exes:
         code_source.append(_FAKE_ESKY_BOOTSTRAP_MODULE)

--- a/esky/bdist_esky/f_py2exe.py
+++ b/esky/bdist_esky/f_py2exe.py
@@ -10,7 +10,6 @@ from __future__ import with_statement
 
 
 import os
-import re
 import sys
 import imp
 import time
@@ -174,8 +173,8 @@ def freeze(dist):
     pass
     #  Create the bootstraping code, using custom code if specified.
     #  It gets stored as a marshalled list of code objects directly in the exe.
-    esky_name = re.escape(dist.distribution.get_name())
-    code_source = ["__esky_name__ = '%s'" % (esky_name,)]
+    esky_name = dist.distribution.get_name()
+    code_source = ["__esky_name__ = %r" % (esky_name,)]
     code_source.append(inspect.getsource(esky.bootstrap))
     if dist.compile_bootstrap_exes:
         from esky.bdist_esky import pypy_libpython


### PR DESCRIPTION
re.escape will incorrectly escape spaces, causing `__boot__.py` to not find executables with spaces in their name. Using %r will correctly escape quotes without the space problem
