### PR TITLE
Fix for issue #27

### DIFF
--- a/esky/winres.py
+++ b/esky/winres.py
@@ -60,12 +60,12 @@ def get_loaded_modules():
             buf = (ctypes.wintypes.HMODULE * sz)()
             if not EnumProcessModules(proc,byref(buf),sz*msz,byref(needed)):
                 raise ctypes.WinError()
-        nmbuf = ctypes.create_string_buffer(300)
+        nmbuf = ctypes.create_unicode_buffer(300)
         i = 0
         while i < needed.value / msz:
             hmod = buf[i]
             i += 1
-            if not k32.GetModuleFileNameA(buf[i],byref(nmbuf),300):
+            if not k32.GetModuleFileNameW(buf[i],byref(nmbuf),300):
                 raise ctypes.WinError()
             yield nmbuf.value
     finally:


### PR DESCRIPTION
This is a proposed fix for the issue described in:
https://github.com/cloudmatrix/esky/issues/27

Instead of going though the entire folder and hash that, we now include,
upon freezing, a "manifest"-file called esky_filelist in the esky-files
folder that contains a list of all the files of the frozen project.
When creating a patch, we calculate the md5 checksum of all the files
listed in esky_filelist, and upon applying the patch we do the same
thing and compare the values, thus ensuring the integrity of the files
but ignoring any extra files in the folder.

By including the filelist with the original frozen application we don't
have to include it in the patches themselves and thus get smaller
patches. We can even apply patches to the filelist!

I have only tested this on Windows, but I see no reason why it shouldn't work on mac or linux.
I didn't have time to add parameters for making the checksum check  optional but it should be pretty straightforward to add if it's something we really want.