### PR TITLE
Allow access to the thrown exception, via the callback, with the DefaultVersionFinder.

### DIFF
--- a/esky/finder.py
+++ b/esky/finder.py
@@ -228,8 +228,8 @@ class DefaultVersionFinder(VersionFinder):
                         else:
                             yield status
                 self._prepare_version(app,version,local_path)
-            except (PatchError,EskyVersionError,EnvironmentError):
-                yield {"status":"retrying","size":None}
+            except (PatchError,EskyVersionError,EnvironmentError), e:
+                yield {"status":"retrying","size":None,"exception":e}
         yield {"status":"ready","path":name}
 
     def _fetch_file_iter(self,app,url):


### PR DESCRIPTION
When a patch error, version error, or environment error occurs, the faulting exception is unknown.  Pass it back along with the '"retrying" callback.
