### PR TITLE
cleanup python 3.3 compatibility + added force-bootstrap-library

### DIFF
--- a/esky/bdist_esky/__init__.py
+++ b/esky/bdist_esky/__init__.py
@@ -244,8 +244,8 @@ class bdist_esky(Command):
                      "function to call just before starting to zip up the app"),
                     ('enable-appdata-dir=', None,
                      "enable new 'appdata' directory layout (will go away after the 0.9.X series)"),
-                    ('force-bootstrap-library=', None,
-                     "By default Esky appends the library.zip to the bootstrap executable when using CX_Freeze, this will force esky to not do that"),
+                    ('detached-bootstrap-library=', None,
+                     "By default Esky appends the library.zip to the bootstrap executable when using CX_Freeze, this will tell esky to not do that, but create a separate library.zip instead"),
                    ]
 
     boolean_options = ["bundle-msvcrt","dont-run-startup-hooks","compile-bootstrap-exes","enable-appdata-dir"]
@@ -265,7 +265,7 @@ class bdist_esky(Command):
         self.pre_freeze_callback = None
         self.pre_zip_callback = None
         self.enable_appdata_dir = False
-        self.force_bootstrap_library = False
+        self.detached_bootstrap_library = False
 
     def finalize_options(self):
         self.set_undefined_options('bdist',('dist_dir', 'dist_dir'))

--- a/esky/bdist_esky/f_cxfreeze.py
+++ b/esky/bdist_esky/f_cxfreeze.py
@@ -162,7 +162,7 @@ def freeze(dist):
                 continue
             
             exepath = dist.copy_to_bootstrap_env(exe.name)
-            if not dist.force_bootstrap_library:
+            if not dist.detached_bootstrap_library:
                 #append library to the bootstrap exe.
                 exepath = dist.copy_to_bootstrap_env(exe.name)
                 bslib = zipfile.PyZipFile(exepath,"a",zipfile.ZIP_STORED)


### PR DESCRIPTION
- Decreased the amount of if/else statements for the Python 3.3 compatiility.
- Added a force-bootstrap-library option for CX_freeze. This prevents appending the library.zip to the bootstrap executable. This is useful when you want to sign your executables with the microsoft signtool (or similair tools).

Tested with Python 3.3
