### PR TITLE
Fixing py2exe compatibility

### DIFF
--- a/esky/bdist_esky/f_py2exe.py
+++ b/esky/bdist_esky/f_py2exe.py
@@ -24,7 +24,7 @@ import ctypes
 
 try:
   from py2exe.build_exe import py2exe
-except:
+except ImportError:
   from py2exe.distutils_build_exe import py2exe
   
 

--- a/esky/bdist_esky/f_py2exe.py
+++ b/esky/bdist_esky/f_py2exe.py
@@ -22,7 +22,11 @@ import zipfile
 import ctypes
 
 
-from py2exe.distutils_build_exe import py2exe
+try:
+  from py2exe.build_exe import py2exe
+except:
+  from py2exe.distutils_build_exe import py2exe
+  
 
 import esky
 from esky.util import is_core_dependency, ESKY_CONTROL_DIR


### PR DESCRIPTION
When trying to use ´py2exe´ was getting an ´RuntimeError´ indicating ´freezer module not found: py2exe´.
Fixed that by correcting py2exe imports.