### PR TITLE
Added a version check to make sure esky will still work with python2.

### DIFF
--- a/esky/bdist_esky/f_py2app.py
+++ b/esky/bdist_esky/f_py2app.py
@@ -116,7 +116,7 @@ def freeze(dist):
                 pass
         copy_to_bootstrap_env("Contents/Resources/include")
         if sys.version_info[:2] < (3, 3):
-            copy_to_bootstrap_env("Contents/Resources/lib/"+pydir+"/config"
+            copy_to_bootstrap_env("Contents/Resources/lib/"+pydir+"/config")
         else:
             copy_to_bootstrap_env("Contents/Resources/lib/"+pydir+"/config-%d.%dm"
                                    % sys.version_info[:2])

--- a/esky/bdist_esky/f_py2app.py
+++ b/esky/bdist_esky/f_py2app.py
@@ -115,8 +115,12 @@ def freeze(dist):
                 #  guard will be more conservative.
                 pass
         copy_to_bootstrap_env("Contents/Resources/include")
-        copy_to_bootstrap_env("Contents/Resources/lib/"+pydir+"/config-%d.%dm"
-                               % sys.version_info[:2])
+        if sys.version_info[:2] < (3, 3):
+            copy_to_bootstrap_env("Contents/Resources/lib/"+pydir+"/config"
+        else:
+            copy_to_bootstrap_env("Contents/Resources/lib/"+pydir+"/config-%d.%dm"
+                                   % sys.version_info[:2])
+
         if "fcntl" not in sys.builtin_module_names:
             dynload = "Contents/Resources/lib/"+pydir+"/lib-dynload"
             for nm in os.listdir(os.path.join(app_dir,dynload)):


### PR DESCRIPTION
I used python 3.3 as a limit, since issue #70 was reported with this
version number, but the real number might not be this one. py2app
changed the naming of the config folder, and I don't know at which
version they did it.