### PR TITLE
Fix to solve "TypeError: bytes or integer address expected instead of…

### DIFF
--- a/esky/sudo/sudo_win32.py
+++ b/esky/sudo/sudo_win32.py
@@ -310,9 +310,9 @@ def spawn_sudo(proxy):
         execinfo.cbSize = sizeof(execinfo)
         execinfo.fMask = SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NOASYNC
         execinfo.hwnd = None
-        execinfo.lpVerb = "runas"
-        execinfo.lpFile = exe[0]
-        execinfo.lpParameters = " ".join(exe[1:])
+        execinfo.lpVerb = b"runas"
+        execinfo.lpFile = exe[0].encode('utf-8')
+        execinfo.lpParameters = " ".join(exe[1:]).encode('utf-8')
         execinfo.lpDirectory = None
         execinfo.nShow = 0
         ShellExecuteEx(byref(execinfo))


### PR DESCRIPTION
Fix to solve "TypeError: bytes or integer address expected instead of str.

instance" on Windows, when trying to get root privileges, with python
3.4. This issue was mentionned in #114.

This fixes ONLY the reported issue on Windows. After applying this fix, an EOFError is raised on
Windows AND on Linux.