### PR TITLE
Sudo and escalation fixes on OSX and Windows.

### DIFF
--- a/esky/sudo/sudo_win32.py
+++ b/esky/sudo/sudo_win32.py
@@ -237,11 +237,16 @@ class SecureStringPipe(base.SecureStringPipe):
         super(SecureStringPipe,self).__init__(token)
         if pipename is None:
             self.pipename = r"\\.\pipe\esky-" + uuid.uuid4().hex
+            if sys.version_info[0] > 2:
+                self.pipename = self.pipename.encode('utf8')
             self.pipe = kernel32.CreateNamedPipeA(
                           self.pipename,0x03,0x00,1,8192,8192,0,None
                         )
         else:
-            self.pipename = pipename
+            if sys.version_info[0] < 3:
+                self.pipename = pipename
+            else:
+                self.pipename = pipename.encode('utf8')
             self.pipe = None
 
     def connect(self):

--- a/esky/util.py
+++ b/esky/util.py
@@ -295,10 +295,11 @@ def extract_zipfile(source,target,name_filter=None):
                 outfilenm = os.path.join(target,nm)
             if not os.path.isdir(os.path.dirname(outfilenm)):
                 os.makedirs(os.path.dirname(outfilenm))
+
             zinfo = zf.getinfo(nm)
-            if hex(zinfo.external_attr) == 2716663808L: # it's a symlink
-                target = zf.read(nm)
-                os.symlink(target, outfilenm)
+            if zinfo.external_attr == 2716663808L: # it's a symlink
+                sym_target = zf.read(nm)
+                os.symlink(sym_target, outfilenm)
                 continue
             infile = zf_open(nm,"r")
             try:
@@ -462,7 +463,10 @@ def copy_ownership_info(src,dst,cur="",default=None):
     else:
         info = default
     if sys.platform != "win32":
-        os.chown(target,info.st_uid,info.st_gid)
+        if sys.version_info[:2] < (3, 3):
+            os.chown(target,info.st_uid,info.st_gid)
+        else:
+            os.chown(target,info.st_uid,info.st_gid, follow_symlinks=False)
     if os.path.isdir(target):
         for nm in os.listdir(target):
             copy_ownership_info(src,dst,os.path.join(cur,nm),default)


### PR DESCRIPTION
- Updated OSX to use bytes for spawning of Sudo process.
- Updated the copy permissions for OSX when preparing
  an updated esky package.
- Fixed esky.util.extract_zipfile which on python 3
  was incorrectly identifying symlinks
- copy_ownership_info on python 3 was following
  symlinks due to the change to chown to follow them by
  default.
- Fixed bug with sudo on win32 with the pipe creation
  expecting a bytes name.


I have tested the escalation (with our code base, which isn't using completely standard esky). For escalation and using prepared updates. On 3.4.

The only question is should I rework this in the case of the esky.util changes to detect version and use the old code for python 2 and the new code for python 3.