### PR TITLE
fix a bug on *nix system about permission copy

### DIFF
--- a/esky/patch.py
+++ b/esky/patch.py
@@ -423,10 +423,13 @@ def calculate_digest(target, hash=hashlib.md5):
             d.update(calculate_digest(os.path.join(target,nm)))   
     elif target.lower().endswith('.zip'):
         try:
-            with zipfile.ZipFile(target, 'r') as z:
+            z=zipfile.ZipFile(target, 'r')
+            try:
                 for info in sorted(z.infolist(), key=lambda x: x.filename):
                     d.update(info.filename)
                     d.update(str(info.CRC).encode('utf-8'))
+            finally:
+                z.close()
         except zipfile.BadZipfile:
             _digest_file(d, target)
     else:

--- a/esky/util.py
+++ b/esky/util.py
@@ -451,26 +451,29 @@ def is_core_dependency(filenm):
     return False
 
 
-def copy_ownership_info(src,dst,cur="",default=None):
+def copy_ownership_info(src, dst, cur="", default=None):
     """Copy file ownership from src onto dst, as much as possible."""
     # TODO: how on win32?
-    source = os.path.join(src,cur)
-    target = os.path.join(dst,cur)
+    source = os.path.join(src, cur)
+    target = os.path.join(dst, cur)
     if default is None:
         default = os.stat(src)
+    is_symlink = os.path.islink(source)
     if os.path.exists(source):
-        info = os.stat(source)
+        if is_symlink:
+            info = os.lstat(source)
+        else:
+            info = os.stat(source)
     else:
         info = default
     if sys.platform != "win32":
-        if sys.version_info[:2] < (3, 3):
-            os.chown(target,info.st_uid,info.st_gid)
+        if is_symlink:
+            os.lchown(target, info.st_uid, info.st_gid)
         else:
-            os.chown(target,info.st_uid,info.st_gid, follow_symlinks=False)
+            os.chown(target, info.st_uid, info.st_gid)
     if os.path.isdir(target):
         for nm in os.listdir(target):
-            copy_ownership_info(src,dst,os.path.join(cur,nm),default)
-
+            copy_ownership_info(src, dst, os.path.join(cur, nm), default)
 
 
 def get_backup_filename(filename):


### PR DESCRIPTION
A previous commit already fixed this bug for python3 but not for python2.  Here is a generic update working with both versions.

This bug breaks esky with py2app on OSX and probably on every *nix system when symbolic link are used in the packaging.  
During an update process on OSX, it tries to apply the owner+group of /usr/bin/python (owner:root, group:wheel) to ./Content/MacOS/python(owner:CURRENT_USER, group:staff).  But the last one is just a symbolic link to the python binary and shouldn't have root rights. 

I also updated the code to be compliant with PEP8.
